### PR TITLE
Fix repo name in the hubs.yaml

### DIFF
--- a/.github/workflows/publish_to_s3.yaml
+++ b/.github/workflows/publish_to_s3.yaml
@@ -25,4 +25,4 @@ jobs:
 
     - name: Copy files to S3
       run: |
-        aws s3 sync hubs.yaml s3://hubverse-hubverse-infrastructure-test --delete
+        aws s3 sync ./hubs.yaml s3://hubverse-hubverse-infrastructure-test --delete

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -1,4 +1,4 @@
 hubs:
 - hub: hubverse-infrastructure-test
   org: Infectious-Disease-Modeling-Hubs
-  repo: hubverse-infrastructure-test
+  repo: hubverse-infrastructure


### PR DESCRIPTION
The original github action test failed because the repo name in hubs.yaml was incorrect (so github was denied permission to assume the required role)

This also fixes the path name of the test data we're pushing to s3.

------

Fixing the repo name was an opportunity to test Pulumi's update process. After providing the correct repo name in the Pulumi script, `pulumi up` correctly detected that two related AWS resources would require updates and was able to apply those updates successfully:

```
pulumi up
Previewing update (hubverse)

View in Browser (Ctrl+O): https://app.pulumi.com/bsweger/hubverse-aws/hubverse/previews/d1b15f38-2669-4d6e-ab7e-de500bb4d265

     Type                               Name                                                       Plan
     pulumi:pulumi:Stack                hubverse-aws-hubverse
 ~   ├─ aws:iam:Role                    hubverse-infrastructure-test-githubaction-role             update
 ~   └─ aws:s3:BucketPublicAccessBlock  hubverse-hubverse-infrastructure-test-public-access-block  update

Resources:
    ~ 2 to update
    6 unchanged

Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:hubverse::hubverse-aws::pulumi:pulumi:Stack::hubverse-aws-hubverse]
    ~ aws:iam/role:Role: (update)
        [id=hubverse-infrastructure-test-githubaction-role]
        [urn=urn:pulumi:hubverse::hubverse-aws::aws:iam/role:Role::hubverse-infrastructure-test-githubaction-role]
        [provider=urn:pulumi:hubverse::hubverse-aws::pulumi:providers:aws::default_6_22_0::6e24b380-0ebb-463f-a7b3-20115f2b5b43]
      ~ assumeRolePolicy: (json) {
          ~ Statement: [
              ~ [0]: {
                      ~ Condition: {
                          ~ StringEquals: {
                              ~ token.actions.githubusercontent.com:sub: "repo:Infectious-Disease-Modeling-Hubs/hubverse-infrastructure-test:ref:refs/heads/main" => "repo:Infectious-Disease-Modeling-Hubs/hubverse-infrastructure:ref:refs/heads/main"
                            }
                        }
                    }
            ]
        }
      ~ description     : "The role assumed by CI/CD for writing data to S3. Can be assumed only by a Github Action workflow from the main branch of Infectious-Disease-Modeling-Hubs/hubverse-infrastructure-test" => "The role assumed by CI/CD for writing data to S3. Can be assumed only by a Github Action workflow from the main branch of Infectious-Disease-Modeling-Hubs/hubverse-infrastructure"
    ~ aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock: (update)
        [id=hubverse-hubverse-infrastructure-test]
        [urn=urn:pulumi:hubverse::hubverse-aws::aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock::hubverse-hubverse-infrastructure-test-public-access-block]
        [provider=urn:pulumi:hubverse::hubverse-aws::pulumi:providers:aws::default_6_22_0::6e24b380-0ebb-463f-a7b3-20115f2b5b43]
      ~ blockPublicPolicy    : true => false
      ~ restrictPublicBuckets: true => false

Do you want to perform this update? yes
Updating (hubverse)

View in Browser (Ctrl+O): https://app.pulumi.com/bsweger/hubverse-aws/hubverse/updates/11

     Type                               Name                                                       Status
     pulumi:pulumi:Stack                hubverse-aws-hubverse
 ~   ├─ aws:s3:BucketPublicAccessBlock  hubverse-hubverse-infrastructure-test-public-access-block  updated (1
 ~   └─ aws:iam:Role                    hubverse-infrastructure-test-githubaction-role             updated (0

Resources:
    ~ 2 updated
    6 unchanged

Duration: 5s
```