### PR TITLE
Fix the resource names specified in the bucket write policy

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -141,8 +141,8 @@ def set_up_hub(hub_info:dict):
                     "s3:PutoObjectAcl",
                 ],
                 resources=[
-                    f'arn:aws:s3:::hubverse-{bucket_name}',
-                    f'arn:aws:s3:::hubverse-{bucket_name}/*'
+                    f'arn:aws:s3:::{bucket_name}',
+                    f'arn:aws:s3:::{bucket_name}/*'
                 ],
             )
         ]


### PR DESCRIPTION
Fixing another bug in the string interpolation for specifying S3 bucket access in the policy that GitHub actions uses for send data to s3.

Ideally, we wouldn't need to string interpolate resource names, but I've had trouble getting Pulumi's output/apply stuff to work.

-----

Pulumi output for apply the changes:

```
pulumi up
Previewing update (hubverse)

View in Browser (Ctrl+O): https://app.pulumi.com/bsweger/hubverse-aws/hubverse/previews/9e13a3cb-90d8-464f-bf07-5a458dceda04

     Type                 Name                                              Plan       Info
     pulumi:pulumi:Stack  hubverse-aws-hubverse
 ~   └─ aws:iam:Policy    hubverse-infrastructure-test-write-bucket-policy  update     [diff: ~policy]

Resources:
    ~ 1 to update
    7 unchanged

Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:hubverse::hubverse-aws::pulumi:pulumi:Stack::hubverse-aws-hubverse]
    ~ aws:iam/policy:Policy: (update)
        [id=arn:aws:iam::767397675902:policy/hubverse-infrastructure-test-write-bucket-policy-a697e05]
        [urn=urn:pulumi:hubverse::hubverse-aws::aws:iam/policy:Policy::hubverse-infrastructure-test-write-bucket-policy]
        [provider=urn:pulumi:hubverse::hubverse-aws::pulumi:providers:aws::default_6_22_0::6e24b380-0ebb-463f-a7b3-20115f2b5b43]
      ~ policy: (json) {
          ~ Statement: [
              ~ [0]: {
                      ~ Resource: [
                          ~ [0]: "arn:aws:s3:::hubverse-hubverse-hubverse-infrastructure-test/*" => "arn:aws:s3:::hubverse-hubverse-infrastructure-test/*"
                          ~ [1]: "arn:aws:s3:::hubverse-hubverse-hubverse-infrastructure-test" => "arn:aws:s3:::hubverse-hubverse-infrastructure-test"
                        ]
                    }
            ]
        }

Do you want to perform this update? yes
Updating (hubverse)

View in Browser (Ctrl+O): https://app.pulumi.com/bsweger/hubverse-aws/hubverse/updates/12

     Type                 Name                                              Status              Info
     pulumi:pulumi:Stack  hubverse-aws-hubverse
 ~   └─ aws:iam:Policy    hubverse-infrastructure-test-write-bucket-policy  updated (0.67s)     [diff: ~polic

Resources:
    ~ 1 updated
    7 unchanged

Duration: 5s
```