### PR TITLE
Add a Pulumi preview workflow

### DIFF
--- a/.github/workflows/pulumi_diff.yaml
+++ b/.github/workflows/pulumi_diff.yaml
@@ -1,0 +1,19 @@
+name: Pulumi
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: main
+    paths:
+      - 'pulumi/**'
+jobs:
+  up:
+    name: Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pulumi/actions@v5
+        with:
+          command: preview
+          stack-name: hubverse/hubverse
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.BSWEGER_PULUMI_DEMO }}

--- a/pulumi/hubs/hubs.yaml
+++ b/pulumi/hubs/hubs.yaml
@@ -2,3 +2,7 @@ hubs:
 - hub: hubverse-infrastructure-test
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-infrastructure
+- hub: example-complex-forecast-hub
+  org: Infectious-Disease-Modeling-Hubs
+  repo: example-complex-forecast-hub
+


### PR DESCRIPTION
This is an attempt to add a Pulumi preview to a PR. It only triggers when there's been a change in the Pulumi folder, so add the example-complex-forecast-hub to the hub list, since we need to move this "hub" to the Hubverse AWS account anyway.