### PR TITLE
Add a Pulumi preview workflow

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -1,0 +1,28 @@
+name: Pulumi
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: main
+    paths:
+      - 'pulumi/**'
+jobs:
+  preview:
+    name: Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::767397675902:role/hubverse-infrastructure-test-githubaction-role
+          aws-region: us-east-1
+      - run: pip install -r requirements.txt
+      - uses: pulumi/actions@v5
+        with:
+          command: preview
+          stack-name: hubverse/hubverse
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.BSWEGER_PULUMI_DEM }}

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::767397675902:role/hubverse-infrastructure-test-githubaction-role
+          role-to-assume: arn:aws:iam::767397675902:role/hubverse-pulumi-role
           aws-region: us-east-1
       - run: pip install -r requirements.txt
       - uses: pulumi/actions@v5

--- a/pulumi/hubs/hubs.yaml
+++ b/pulumi/hubs/hubs.yaml
@@ -2,3 +2,7 @@ hubs:
 - hub: hubverse-infrastructure-test
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-infrastructure
+- hub: example-complex-forecast-hub
+  org: Infectious-Disease-Modeling-Hubs
+  repo: example-complex-forecast-hub
+


### PR DESCRIPTION
This is an attempt to add a Pulumi preview to a PR. It only triggers when there's been a change in the Pulumi folder, so add the example-complex-forecast-hub to the hub list, since we need to move this "hub" to the Hubverse AWS account anyway.