### PR TITLE
Onboard example-complex-forecast-hub

### DIFF
--- a/pulumi/hubs/hubs.yaml
+++ b/pulumi/hubs/hubs.yaml
@@ -2,3 +2,6 @@ hubs:
 - hub: hubverse-infrastructure-test
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-infrastructure
+- hub: example-complex-forecast-hub
+  org: Infectious-Disease-Modeling-Hubs
+  repo: example-complex-forecast-hub


### PR DESCRIPTION
First example of using the Pulumi prototype to onboard a Hubverse hub to the cloud.

Here we're just adding the new hub to a `.yaml` that lists all hubs on the cloud.

When we decide on an infrastructure as code tool, I'd expect this type of PR to be automatically updated with a preview of the AWS components that will be added or changed. For now, I will playing the part of the robot in the PR comments.

