### PR TITLE
Bsweger/update naming conventions

### DIFF
--- a/pulumi/hubs/hub_setup.py
+++ b/pulumi/hubs/hub_setup.py
@@ -19,11 +19,11 @@ def set_up_hub(hub_info:dict):
     org = hub_info['org']
     hub = hub_info['hub']
 
-    bucket_name = f'hubverse-{hub}'
+    bucket_name = f'{hub}'
     bucket_write_policy_name = f'{hub}-write-bucket-policy'
     bucket_read_policy_name = f'{hub}-read-bucket-policy'
-    github_policy_name = f'{hub}-githubaction-policy'
-    github_role_name = f"{hub}-githubaction-role"
+    github_policy_name = f'{hub}'
+    github_role_name = f'{hub}'
     tags={'hub': hub}
 
 
@@ -40,7 +40,7 @@ def set_up_hub(hub_info:dict):
     # By default, new S3 buckets do not allow public access. Updating
     # those settings will allow us to create a bucket policy for public access.
     hub_bucket_public_access_block = aws.s3.BucketPublicAccessBlock(
-        resource_name=f'{bucket_name}-public-access-block',
+        resource_name=f'{hub}-public-access-block',
         bucket=hub_bucket.id,
         block_public_acls=True,
         ignore_public_acls=True,
@@ -143,6 +143,7 @@ def set_up_hub(hub_info:dict):
     )
     
     bucket_write_policy = aws.iam.Policy(
+        name=bucket_write_policy_name,
         resource_name=bucket_write_policy_name,
         description=f'Policy attached to {github_role_name}. It allows writing to the {bucket_name} S3 bucket',
         policy=s3_policy.json,

--- a/pulumi/hubs/hubs.yaml
+++ b/pulumi/hubs/hubs.yaml
@@ -2,6 +2,3 @@ hubs:
 - hub: hubverse-infrastructure-test
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-infrastructure
-- hub: example-complex-forecast-hub
-  org: Infectious-Disease-Modeling-Hubs
-  repo: example-complex-forecast-hub

--- a/pulumi/hubs/hubs.yaml
+++ b/pulumi/hubs/hubs.yaml
@@ -1,3 +1,5 @@
+# This is an MVP config for getting hubs onboarded to the cloud via Pulumi. If we decide to
+# adopt Pulumi, the next step would be reading this information from each hub's admin.json config.
 hubs:
 - hub: hubverse-infrastructure-test
   org: Infectious-Disease-Modeling-Hubs


### PR DESCRIPTION
Make AWS resource names less verbose

This also removes the convention for prefixing S3 bucket names
with "hubverse-" (with the idea that it will be less confusing
if the S3 bucket name matches what's in a hub's admin.json
config file; if there's a naming collision, the hub admin will
have to pick a new bucket name)

(also remove sample complex forecast hub from Pulumi control so
we can make updates without breaking Evans S3 sync)