### PR TITLE
Add a new hub to AWS: hubverse-cloud

### DIFF
--- a/pulumi/hubs/hubs.yaml
+++ b/pulumi/hubs/hubs.yaml
@@ -4,3 +4,6 @@ hubs:
 - hub: hubverse-infrastructure-test
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-infrastructure
+- hub: hubverse-cloud
+  org: Infectious-Disease-Modeling-Hubs
+  repo: hubverse-cloud


### PR DESCRIPTION
hubverse-cloud is an existing repo that we've been using to test our S3 syncing. Now that we're ready to update the S3 sync GitHub action to get info from hubs' admin.json, we need to make sure this hub has AWS resources