### PR TITLE
Bsweger/fix iam permissions

### DIFF
--- a/.github/workflows/pulumi_update.yaml
+++ b/.github/workflows/pulumi_update.yaml
@@ -1,5 +1,6 @@
 name: Pulumi Update
 on:
+  workflow_dispatch:
   push:
     branches: main
 

--- a/pulumi/hubs/hubs.yaml
+++ b/pulumi/hubs/hubs.yaml
@@ -8,6 +8,3 @@ hubs:
 - hub: hubverse-cloud
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-cloud
-- hub: hubverse-march-madness
-  org: Infectious-Disease-Modeling-Hubs
-  repo: hubverse-march-madness


### PR DESCRIPTION
First, remove the `march-madness` hub infra created via the prior PR (before we hit a permissions error).