### PR TITLE
Add license and Pulumi logo for open source team license

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,15 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.1.11
   hooks:
-    # Run the linter.
-    - id: ruff
-      args: [ --fix ]
-    # Run the formatter.
-    - id: ruff-format
+  # Run the linter.
+  - id: ruff
+    args: [ --fix ]
+  # Run the formatter.
+  - id: ruff-format
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+  - id: codespell
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: 'v1.8.0'
   hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Consortium of Infectious Disease Modeling Hubs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Hubverse Infrastructure
 
-This repository belongs to the Hubverse, a project that provides open tools for collaborative modeling:
+
+<img src="https://www.pulumi.com/images/pricing/team-oss.svg" alt="Pulumi Team edition for open source" style="width:100px; float: left; margin-right: 10px;"/>
+
+This repository uses [Pulumi](https://www.pulumi.com/) to provision cloud resources for the Hubverse, a project that provides open tools for collaborative modeling:
 https://hubdocs.readthedocs.io/en/latest/.
 
 ## Background
@@ -26,15 +29,6 @@ Each cloud-enabled hub requires the following AWS resources:
     - A _trust policy_ that stipulates the role can only be used by GitHub Actions that originate from the main branch of the hub's repository.
     - A _permission policy_ that grants write access to the hub's S3 bucket.
 
-This repository contains two Pulumi-related GitHub workflows create and destroy the above AWS resources as needed:
-
-* `pulumi_preview.yml`: runs when a pull request is opened and reports any related AWS resource changes
-* `pulumi_update.yml`: runs when a pull request is merged and applies the AWS changes
-
-The GitHub actions use an OIDC identity provider to authenticate with AWS.
-
-![Github and OIDC](https://docs.github.com/assets/cb-63262/mw-1440/images/help/actions/oidc-architecture.webp)
-
 
 ## Onboarding a Hub
 
@@ -46,7 +40,16 @@ TODO: Add detailed instructions for onboarding a hub to the cloud.
 
 The code here uses a simple .yaml file that lists the cloud-enabled hubs. For each hub on the list, the Pulumi entry point invokes a Python function that provisions the required AWS resources.
 
-If you're a Hubverse developer running Pulumi locally, you will need to setup the project, and you will need the required Hubverse AWS credentials.
+### Required permissions
+
+This repo uses two GitHub workflows to manage Hubverse AWS resources:
+
+1. `pulumi_preview.yaml`: runs when a PR is opened and generates a report of infrastructure updates that would result from the proposed code changes
+2. `pulumi_update.yaml`: runs when a PR is merged to the default branch and updates AWS resources as outlined in the preview
+
+Both workflows use a GitHub OIDC identity provider to assume an IAM role called `hubverse-administration`. This role grants the necessary permissions needed to create, manage, and destroy Hubverse AWS resources.
+
+If you're a Hubverse developer who wants to use Pulumi locally (using [Pulumi's CLI](https://www.pulumi.com/docs/cli/), for example), you will need access to an AWS role with the same permissions used by the GitHub workflows.
 
 ### Setup instructions
 


### PR DESCRIPTION
Adding a license and the Pulumi logo as part of applying for an open source team license: https://github.com/pulumi/team-edition-for-open-source?tab=readme-ov-file#how-to-apply

This changeset also does a few pre-committ fixups, including adding a spell check.