### PR TITLE
Update Pulumi workflows to use different AWS roles

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Configure AWS credentials 🔐
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::767397675902:role/hubverse-administration
+          role-to-assume: arn:aws:iam::767397675902:role/hubverse-infrastructure-read-role
           aws-region: us-east-1
 
       - name: Previewing infrastructure 👀

--- a/.github/workflows/pulumi_update.yaml
+++ b/.github/workflows/pulumi_update.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Configure AWS credentials 🔐
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::767397675902:role/hubverse-administration
+          role-to-assume: arn:aws:iam::767397675902:role/hubverse-infrastructure-write-role
           aws-region: us-east-1
 
       - name: Updating infrastructure 🛠️

--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ The code here uses a simple .yaml file that lists the cloud-enabled hubs. For ea
 
 ### Required permissions
 
-This repo uses two GitHub workflows to manage Hubverse AWS resources:
+This repo uses two GitHub workflows to manage Hubverse AWS resources. Each workflow assumes an IAM role with the permissions it needs (via GitHub's OIDC identity provider).
 
-1. `pulumi_preview.yaml`: runs when a PR is opened and generates a report of infrastructure updates that would result from the proposed code changes
-2. `pulumi_update.yaml`: runs when a PR is merged to the default branch and updates AWS resources as outlined in the preview
+| GitHub Workflow                                                 | Trigger                | Infrastructure Permissions  |
+| --------------------------------------------------------------- | ---------------------- | --------------------------- |
+| [`pulumi_preview.yaml`](.github/workflows/pulumi_preview.yaml)  | PR to `main` & ad-hoc  | read-only                   |
+| [`pulumi_update.yaml`](.github/workflows/pulumi_update.yaml)    | merge to `main`        | read update create delete   |
 
-Both workflows use a GitHub OIDC identity provider to assume an IAM role called `hubverse-administration`. This role grants the necessary permissions needed to create, manage, and destroy Hubverse AWS resources.
 
-If you're a Hubverse developer who wants to use Pulumi locally (using [Pulumi's CLI](https://www.pulumi.com/docs/cli/), for example), you will need access to an AWS role with the same permissions used by the GitHub workflows.
+If you're a Hubverse developer who wants to use Pulumi locally (using [Pulumi's CLI](https://www.pulumi.com/docs/cli/), for example), you will need access to AWS credentials with the same permissions used by the GitHub workflows.
 
 ### Setup instructions
 


### PR DESCRIPTION
Resolves Infectious-Disease-Modeling-Hubs/hubverse-cloud#67

Now that we're out of demo mode, apply the principle of least privilege to our Pulumi workflows. 

The "preview" workflow should only have read access to AWS resources, especially since it runs against feature branch code. The role with write access is reserved for the update action, which runs when a PR is merged to the repo's main branch.

------

We won't be able to see the "update" workflow in action until we onboard the next hub to the cloud (most likely example data), I following these steps to test the new roles locally:

1. Created an AWS account and attached the same "read" policy that is attached to the IAM read role assumed by the `pulumi_preview` action
2. Added a fake hub to `hubs.yaml`
3. Using the Pulumi CLI: `pulumi preview` generated the correct preview:
```
pulumi preview
Previewing update (hubverse)

     Type                               Name                               Plan
     pulumi:pulumi:Stack                hubverse-aws-hubverse
 +   ├─ aws:s3:Bucket                   fake-hub-test                      create
 +   ├─ aws:s3:BucketPublicAccessBlock  fake-hub-test-public-access-block  create
 +   ├─ aws:s3:BucketPolicy             fake-hub-test-read-bucket-policy   create
 +   ├─ aws:iam:Role                    fake-hub-test                      create
 +   ├─ aws:iam:RolePolicyAttachment    fake-hub-test                      create
 +   └─ aws:iam:Policy                  fake-hub-test-write-bucket-policy  create

Resources:
    + 6 to create
    13 unchanged
```

4. Using the Pulumi CLI: `pulumi up` failed because my test account did not have the "write" policy attached:
```
Resources:
    + 6 to create
    13 unchanged

Do you want to perform this update? yes
Updating (hubverse)

     Type                 Name                               Status                  Info
     pulumi:pulumi:Stack  hubverse-aws-hubverse              **failed**              1 error
 +   ├─ aws:s3:Bucket     fake-hub-test                      **creating failed**     1 error
 +   ├─ aws:iam:Policy    fake-hub-test-write-bucket-policy  **creating failed**     1 error
 +   └─ aws:iam:Role      fake-hub-test                      **creating failed**     1 error

[snip]

Resources:
    13 unchanged
```
5. Updated the test user to add the "write" policy attached to the IAM write role assumed by the `pulumi_update` action.
6. Using the Pulumi CLI: `pulumi up` now succeeds:
```
Do you want to perform this update? yes
Updating (hubverse)

     Type                               Name                               Status
     pulumi:pulumi:Stack                hubverse-aws-hubverse
 +   ├─ aws:s3:Bucket                   fake-test-hub                      created (1s)
 +   ├─ aws:iam:Role                    fake-test-hub                      created (1s)
 +   ├─ aws:iam:Policy                  fake-test-hub-write-bucket-policy  created (1s)
 +   ├─ aws:iam:RolePolicyAttachment    fake-test-hub                      created (0.32s)
 +   ├─ aws:s3:BucketPublicAccessBlock  fake-test-hub-public-access-block  created (0.67s)
 +   └─ aws:s3:BucketPolicy             fake-test-hub-read-bucket-policy   created (0.45s)

Resources:
    + 6 created
    13 unchanged
```
7. Deleted the fake hub resources, also using the new "write" permission policy

