### PR TITLE
Add infrastructure to support the the automated transform of model-output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,24 @@ At this time, the Hubverse will provide hosting for hubs that opt-in to cloud st
 This repository contains the [Pulumi](https://www.pulumi.com/) project that provisions the AWS resources for each cloud-enabled hub hosted on the Hubverse AWS account.
 
 
-### Supported Cloud Providers
+### AWS
 
-At this time, the Hubverse supports Amazon Web Services (AWS) as a cloud provider.
+At this time, Amazon Web Services (AWS) is the only cloud provider supported by Hubverse hosting.
 
+The code in this repository creates two categories of AWS resources:
+1. Resources that are shared across all hubs or are used for Hubverse administration.
+2. Resources created specifically for each hub.
 
-#### AWS
+#### Shared cloud resources
 
-Each cloud-enabled hub requires the following AWS resources:
+These resources are created one time for the entire Hubverse:
+
+1. As S3 bucket to store shared files. The contents are not publicly accessible because they are for internal use.
+2. An AWS lambda function that transforms model-output files into a standardized format.
+
+#### Hub-specific cloud resources
+
+Each cloud-enabled hub requires several dedicated AWS resources. These resources are created for each hub:
 
 1. An S3 bucket to store data (with public read access).
 2. An IAM _role_ that can be assumed by GitHub Actions. This role has two associated _policies_:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {text = "MIT"}
 
 requires-python = ">=3.11,<3.12"
 dependencies = [
+    "boto3",
     "cloudpathlib[s3]",
     "pulumi<4.0.0,>=3.0.0",
     "pulumi-aws<7.0.0,>=6.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {text = "MIT"}
 
 requires-python = ">=3.11,<3.12"
 dependencies = [
+    "cloudpathlib[s3]",
     "pulumi<4.0.0,>=3.0.0",
     "pulumi-aws<7.0.0,>=6.0.2",
     "PyYAML>=6.0.1",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,9 @@ arpeggio==2.0.2
 attrs==23.2.0
     # via parver
 boto3==1.34.86
-    # via cloudpathlib
+    # via
+    #   cloudpathlib
+    #   hubverse-infrastructure (pyproject.toml)
 botocore==1.34.86
     # via
     #   boto3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,10 +8,22 @@ arpeggio==2.0.2
     # via parver
 attrs==23.2.0
     # via parver
+boto3==1.34.86
+    # via cloudpathlib
+botocore==1.34.86
+    # via
+    #   boto3
+    #   s3transfer
+cloudpathlib[s3]==0.18.1
+    # via hubverse-infrastructure (pyproject.toml)
 dill==0.3.8
     # via pulumi
 grpcio==1.60.1
     # via pulumi
+jmespath==1.0.1
+    # via
+    #   boto3
+    #   botocore
 parver==0.5
     # via pulumi-aws
 protobuf==4.25.3
@@ -22,13 +34,21 @@ pulumi==3.112.0
     #   pulumi-aws
 pulumi-aws==6.29.0
     # via hubverse-infrastructure (pyproject.toml)
+python-dateutil==2.9.0.post0
+    # via botocore
 pyyaml==6.0.1
     # via
     #   hubverse-infrastructure (pyproject.toml)
     #   pulumi
+s3transfer==0.10.1
+    # via boto3
 semver==2.13.0
     # via
     #   pulumi
     #   pulumi-aws
 six==1.16.0
-    # via pulumi
+    # via
+    #   pulumi
+    #   python-dateutil
+urllib3==2.2.1
+    # via botocore

--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -2,9 +2,6 @@
 # adopt Pulumi, the next step would be reading this information from each hub's admin.json config.
 # hub = admin.json: cloud.storage
 hubs:
-- hub: hubverse-infrastructure-test
-  org: Infectious-Disease-Modeling-Hubs
-  repo: hubverse-infrastructure
 - hub: hubverse-cloud
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-cloud

--- a/src/hubverse_infrastructure/main.py
+++ b/src/hubverse_infrastructure/main.py
@@ -3,8 +3,13 @@
 import yaml
 
 from hubverse_infrastructure.hubs.hub_setup import set_up_hub
+from hubverse_infrastructure.shared.hubverse_transforms import create_transform_infrastructure
+
+# First, create infrastructure components that are shared across hubs.
+create_transform_infrastructure()
 
 
+# Then, create hub-specific infrastructure.
 def get_hubs() -> list[dict]:
     """Get the list of cloud-enabled hubs."""
     with open("hubs/hubs.yaml", "r") as file:

--- a/src/hubverse_infrastructure/shared/hubverse_transforms.py
+++ b/src/hubverse_infrastructure/shared/hubverse_transforms.py
@@ -1,0 +1,58 @@
+"""Create the AWS infrastructure needed to run Hubverse model-output transformations as Lambda functions."""
+import pulumi_aws as aws
+from pulumi import ResourceOptions  # type: ignore
+
+
+def create_bucket(bucket_name: str) -> aws.s3.Bucket:
+    """
+    Create the S3 bucket used to store shared Hubverse assets and give the AWS Lambda service read access to it.
+    """
+
+    hubverse_asset_bucket = aws.s3.Bucket(bucket_name, bucket=bucket_name, tags={"hub": "hubverse"})
+
+    # Create an S3 policy that will the AWS Lambda service to read from the bucket
+    s3_policy_document = aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                sid="LambdaReadBucket",
+                actions=[
+                    "s3:GetObject",
+                ],
+                principals=[
+                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                        type="Service", identifiers=["lambda.amazonaws.com"]
+                    )
+                ],
+                resources=[f"arn:aws:s3:::{bucket_name}/*"],
+            ),
+            aws.iam.GetPolicyDocumentStatementArgs(
+                sid="LambdaListBucket",
+                actions=[
+                    "s3:ListBucket",
+                ],
+                principals=[
+                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                        type="Service", identifiers=["lambda.amazonaws.com"]
+                    )
+                ],
+                resources=[f"arn:aws:s3:::{bucket_name}"],
+            ),
+        ]
+    )
+
+    # Apply the policy to the bucket.
+    aws.s3.BucketPolicy(
+        resource_name=f"{bucket_name}-read-bucket-policy",
+        bucket=hubverse_asset_bucket.id,
+        policy=s3_policy_document.json,
+        opts=ResourceOptions(depends_on=[hubverse_asset_bucket]),
+    )
+
+    return hubverse_asset_bucket
+
+
+def create_transform_infrastructure():
+    bucket_name = "hubverse-assets"
+    hubverse_bucket = create_bucket(bucket_name)
+
+    return hubverse_bucket

--- a/src/hubverse_infrastructure/shared/hubverse_transforms.py
+++ b/src/hubverse_infrastructure/shared/hubverse_transforms.py
@@ -1,42 +1,49 @@
 """Create the AWS infrastructure needed to run Hubverse model-output transformations as Lambda functions."""
+import io
+from zipfile import ZipFile
+
+import boto3
+import pulumi
 import pulumi_aws as aws
+from botocore.exceptions import ClientError
 from cloudpathlib import CloudPath
 from pulumi import ResourceOptions  # type: ignore
 
 
-def create_bucket(bucket_name: str) -> aws.s3.Bucket:
+def create_bucket(bucket_name: str) -> aws.s3.BucketV2:
     """
     Create the S3 bucket used to store shared Hubverse assets and give the AWS Lambda service read access to it.
     """
 
-    hubverse_asset_bucket = aws.s3.Bucket(bucket_name, bucket=bucket_name, tags={"hub": "hubverse"})
+    hubverse_asset_bucket = aws.s3.BucketV2(bucket_name, bucket=bucket_name, tags={"hub": "hubverse"})
 
     # Create an S3 policy that allows the AWS Lambda service to read from the bucket
     # (this is a permissive read policy because it applies to any lambda function, but the Hubverse
-    # deals in open source data and code, so we can leave keep it open for simplicity)
+    # deals in open source data and code, so we can leave keep it open for simplicity).
     s3_policy_document = aws.iam.get_policy_document(
         statements=[
             aws.iam.GetPolicyDocumentStatementArgs(
-                sid="LambdaReadBucket",
+                sid="ReadAssetBucket",
                 actions=[
                     "s3:GetObject",
+                    "s3:GetObjectAcl",
                 ],
                 principals=[
                     aws.iam.GetPolicyDocumentStatementPrincipalArgs(
                         type="Service", identifiers=["lambda.amazonaws.com"]
-                    )
+                    ),
                 ],
                 resources=[f"arn:aws:s3:::{bucket_name}/*"],
             ),
             aws.iam.GetPolicyDocumentStatementArgs(
-                sid="LambdaListBucket",
+                sid="ListAssetBucket",
                 actions=[
                     "s3:ListBucket",
                 ],
                 principals=[
                     aws.iam.GetPolicyDocumentStatementPrincipalArgs(
                         type="Service", identifiers=["lambda.amazonaws.com"]
-                    )
+                    ),
                 ],
                 resources=[f"arn:aws:s3:::{bucket_name}"],
             ),
@@ -132,7 +139,7 @@ def create_lambda_execution_permissions(lambda_name: str) -> aws.iam.Role:
 
 
 def create_transform_lambda(
-    lambda_name: str, package_location: CloudPath, lambda_role: aws.iam.Role
+    lambda_name: str, package_location: CloudPath, lambda_role: aws.iam.Role, hubverse_asset_bucket: aws.s3.BucketV2
 ) -> aws.lambda_.Function:
     """
     Create the scaffolding for the Lambda function that transforms a model-output file.
@@ -140,6 +147,11 @@ def create_transform_lambda(
 
     s3_bucket = package_location.drive
     s3_key = package_location.key
+
+    # Using arn.apply below ensures that the create_lambda_package_placeholder doesn't run
+    # until the hubverse_asset_bucket exists (because a bucket's arn isn't available until
+    # the bucket has been physically created on AWS).
+    hubverse_asset_bucket.arn.apply(lambda _: create_lambda_package_placeholder(s3_bucket, s3_key))
 
     transform_lambda = aws.lambda_.Function(
         name=lambda_name,
@@ -153,18 +165,53 @@ def create_transform_lambda(
         s3_key=s3_key,
         tags={"hub": "hubverse"},
         timeout=210,
+        opts=ResourceOptions(depends_on=[hubverse_asset_bucket]),
     )
 
     return transform_lambda
 
 
+def create_lambda_package_placeholder(s3_bucket: str, s3_key: str):
+    """Create a lambda package placeholder in S3 if necessary."""
+
+    # if we're in a dry run (such as a Pulumi preview), skip this
+    if pulumi.runtime.is_dry_run():
+        return
+
+    # This function creates a "scaffolding" lambda, which is designed to run packaged function code
+    # stored in an S3 bucket. We don't want Pulumi to manage the lambda's actual code because
+    # we don't want the hubverse transform functionality tightly coupled to the Hubverse-managed
+    # AWS infrastructure. However, if the code package (which is deployed by the hubverse-transform
+    # repo) doesn't exist yet, we need to create a placeholder zip file. It's a chicken-and-egg problem
+    # that should only occur until the hubverse-transform deployment pipeline is up and running)
+
+    s3 = boto3.resource("s3")
+    lambda_package = s3.Object(s3_bucket, s3_key)
+    try:
+        lambda_package.get()
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "NoSuchKey":
+            placeholder_zip = io.BytesIO()
+            zip_file = ZipFile(placeholder_zip, "w")
+            zip_file.writestr("placeholder", b"lambda function placeholder")
+            zip_file.close()
+            placeholder_zip.seek(0)
+            lambda_package.put(Body=placeholder_zip)
+        else:
+            raise Exception(f"Boto error when checking for existing lambda package: {s3_bucket}/{s3_key}") from e
+    except Exception as e:
+        raise Exception(f"Error when checking for existing lambda package: {s3_bucket}/{s3_key}") from e
+
+    return lambda_package
+
+
 def create_transform_infrastructure():
     bucket_name = "hubverse-assets"
     lambda_name = "hubverse-transform-model-output"
-    lambda_package_location = "s3://hubverse-assets/lambda/hubverse-transform.zip"
+    lambda_package_location = "s3://hubverse-assets/lambda/hubverse-transform-model-output.zip"
 
     lambda_package_path = CloudPath(lambda_package_location)
 
-    create_bucket(bucket_name)
+    bucket = create_bucket(bucket_name)
     lambda_role = create_lambda_execution_permissions(lambda_name)
-    create_transform_lambda(lambda_name, lambda_package_path, lambda_role)
+    create_transform_lambda(lambda_name, lambda_package_path, lambda_role, bucket)

--- a/src/hubverse_infrastructure/shared/hubverse_transforms.py
+++ b/src/hubverse_infrastructure/shared/hubverse_transforms.py
@@ -11,7 +11,9 @@ def create_bucket(bucket_name: str) -> aws.s3.Bucket:
 
     hubverse_asset_bucket = aws.s3.Bucket(bucket_name, bucket=bucket_name, tags={"hub": "hubverse"})
 
-    # Create an S3 policy that will the AWS Lambda service to read from the bucket
+    # Create an S3 policy that allows the AWS Lambda service to read from the bucket
+    # (this is a permissive read policy because it applies to any lambda function, but the Hubverse
+    # deals in open source data and code, so we can leave keep it open for simplicity)
     s3_policy_document = aws.iam.get_policy_document(
         statements=[
             aws.iam.GetPolicyDocumentStatementArgs(
@@ -52,11 +54,38 @@ def create_bucket(bucket_name: str) -> aws.s3.Bucket:
     return hubverse_asset_bucket
 
 
-def create_transform_lambda(lambda_name: str, package_location: CloudPath) -> aws.lambda_.Function:
-    """
-    Create the scaffolding for the Lambda function that transforms a model-output file.
-    """
+def create_cloudwatch_write_policy(policy_name: str):
+    # Create a policy that allows write access to AWS CloudWatch logs
+    # (we'll need to attach this to the Lambda execution role)
+    cloudwatch_write_policy_document = aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                actions=[
+                    "logs:PutLogEvents",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                ],
+                resources=["arn:aws:logs:*:*:*"],
+            ),
+        ]
+    )
 
+    cloudwatch_write_policy_name = policy_name
+    cloudwatch_write_policy = aws.iam.Policy(
+        name=cloudwatch_write_policy_name,
+        resource_name=cloudwatch_write_policy_name,
+        description="Policy that allows writing to AWS CloudWatch logs",
+        policy=cloudwatch_write_policy_document.json,
+        tags={"hub": "hubverse"},
+    )
+
+    return cloudwatch_write_policy
+
+
+def create_lambda_execution_permissions(lambda_name: str) -> aws.iam.Role:
+    """Create IAM role that the hubverse-transform lambda will assume and attach the necessary permissions."""
+
+    # Create the role used by the lambda function
     lambda_role_document = aws.iam.get_policy_document(
         statements=[
             aws.iam.GetPolicyDocumentStatementArgs(
@@ -79,6 +108,22 @@ def create_transform_lambda(lambda_name: str, package_location: CloudPath) -> aw
         assume_role_policy=lambda_role_document.json,
         tags={"hub": "hubverse"},
     )
+
+    # Create a policy that allows writes to AWS CloudWatch logs and attach it to the lambda role
+    cloudwatch_write_policy = create_cloudwatch_write_policy("hubverse-cloudwatch-write-policy")
+    aws.iam.RolePolicyAttachment(
+        resource_name=f"{lambda_name}-cloudwatch-policy", role=lambda_role.name, policy_arn=cloudwatch_write_policy.id
+    )
+
+    return lambda_role
+
+
+def create_transform_lambda(
+    lambda_name: str, package_location: CloudPath, lambda_role: aws.iam.Role
+) -> aws.lambda_.Function:
+    """
+    Create the scaffolding for the Lambda function that transforms a model-output file.
+    """
 
     s3_bucket = package_location.drive
     s3_key = package_location.key
@@ -108,4 +153,5 @@ def create_transform_infrastructure():
     lambda_package_path = CloudPath(lambda_package_location)
 
     create_bucket(bucket_name)
-    create_transform_lambda(lambda_name, package_location=lambda_package_path)
+    lambda_role = create_lambda_execution_permissions(lambda_name)
+    create_transform_lambda(lambda_name, lambda_package_path, lambda_role)

--- a/src/hubverse_infrastructure/shared/hubverse_transforms.py
+++ b/src/hubverse_infrastructure/shared/hubverse_transforms.py
@@ -151,7 +151,7 @@ def create_transform_lambda(
     """
 
     s3_bucket = package_location.drive
-    s3_key = package_location.key
+    s3_key = package_location.key  # type: ignore
 
     # Using arn.apply below ensures that the create_lambda_package_placeholder doesn't run
     # until the hubverse_asset_bucket exists (because a bucket's arn isn't available until

--- a/src/hubverse_infrastructure/shared/hubverse_transforms.py
+++ b/src/hubverse_infrastructure/shared/hubverse_transforms.py
@@ -61,9 +61,12 @@ def create_bucket(bucket_name: str) -> aws.s3.BucketV2:
     return hubverse_asset_bucket
 
 
-def create_cloudwatch_write_policy(policy_name: str):
-    # Create a policy that allows write access to AWS CloudWatch logs
-    # (we'll need to attach this to the Lambda execution role)
+def create_cloudwatch_write_policy(policy_name: str) -> aws.iam.Policy:
+    """
+    Create a policy that allows write access to AWS CloudWatch logs
+    (we'll need to attach this to the Lambda execution role)
+    """
+
     cloudwatch_write_policy_document = aws.iam.get_policy_document(
         statements=[
             aws.iam.GetPolicyDocumentStatementArgs(
@@ -90,7 +93,9 @@ def create_cloudwatch_write_policy(policy_name: str):
 
 
 def create_lambda_execution_permissions(lambda_name: str) -> aws.iam.Role:
-    """Create IAM role that the hubverse-transform lambda will assume and attach the necessary permissions."""
+    """
+    Create IAM role that the hubverse-transform lambda will assume and attach the necessary permissions.
+    """
 
     # Because getting ARNs from Pulumi resources is terrible, the code below manually constructs the ARN
     # of the hubverse-transform lambda function. To do that, we need the current AWS account id and its
@@ -172,13 +177,15 @@ def create_transform_lambda(
 
 
 def create_lambda_package_placeholder(s3_bucket: str, s3_key: str):
-    """Create a lambda package placeholder in S3 if necessary."""
+    """
+    Create a lambda package placeholder in S3 if necessary.
+    """
 
     # if we're in a dry run (such as a Pulumi preview), skip this
     if pulumi.runtime.is_dry_run():
         return
 
-    # This function creates a "scaffolding" lambda, which is designed to run packaged function code
+    # This module creates a "scaffolding" lambda, which is designed to run packaged function code
     # stored in an S3 bucket. We don't want Pulumi to manage the lambda's actual code because
     # we don't want the hubverse transform functionality tightly coupled to the Hubverse-managed
     # AWS infrastructure. However, if the code package (which is deployed by the hubverse-transform
@@ -202,14 +209,15 @@ def create_lambda_package_placeholder(s3_bucket: str, s3_key: str):
     except Exception as e:
         raise Exception(f"Error when checking for existing lambda package: {s3_bucket}/{s3_key}") from e
 
-    return lambda_package
-
 
 def create_transform_infrastructure():
+    """
+    Create all AWS infrastructure required to support the lambda function that will
+    operate on cloud-based model-output files.
+    """
     bucket_name = "hubverse-assets"
     lambda_name = "hubverse-transform-model-output"
     lambda_package_location = "s3://hubverse-assets/lambda/hubverse-transform-model-output.zip"
-
     lambda_package_path = CloudPath(lambda_package_location)
 
     bucket = create_bucket(bucket_name)


### PR DESCRIPTION
Resolves #36 (click here for additional context)

This PR creates the AWS infrastructure required for the lambda function we'll use to transform incoming model-output files after they're synced to S3.

These changes are part of work to onboard hubs to the cloud:
<img width="908" alt="image" src="https://github.com/Infectious-Disease-Modeling-Hubs/hubverse-infrastructure/assets/540544/93010bde-74eb-4fab-a79a-b44f2b2029fc">

**Details**

This PR creates the lambda function (and supporting IAM roles/policies, as well as an S3 bucket) that each hub's S3 bucket will trigger when new model-output data arrives.

While it's important to define the function and create its corresponding permissions via Pulumi, the actual code that's executed by the lambda is not created here. We want to maintain a loose coupling between the Hubverse's infrastructure and the data transform function.

(The transform function itself lives in `[hubverse-transform](https://github.com/Infectious-Disease-Modeling-Hubs/hubverse-transform)` and is [under review at this time](https://github.com/Infectious-Disease-Modeling-Hubs/hubverse-transform/pull/1))

**A note about tests**

Pulumi's [`aws.iam.getPolicyDocument`](https://www.pulumi.com/registry/packages/aws/api-docs/iam/getpolicydocument) function--used heavily in this code base--is not available in testing mode. Since IAM policies is a lot of what we're doing, this unavailability presents a challenge for developing a robust test suite. It would take several additional hours to figure this out, and I decided to spend time elsewhere (though can come back to this based on reviewer feedback).

**Next steps**

Once this PR is merged, the next step will be updating the hub-specific bits required for the transforms to work:

1. Add a lambda trigger to each hub's S3 bucket
2. Add each hub's bucket write policy to the lambda's IAM execution role