### PR TITLE
Bsweger/add hub specific lambda infra

### DIFF
--- a/src/hubverse_infrastructure/hubs/hub_setup.py
+++ b/src/hubverse_infrastructure/hubs/hub_setup.py
@@ -12,5 +12,6 @@ def set_up_hub(hub_info: dict):
     a different bucket name.
     """
 
-    create_s3_infrastructure(hub_info)
+    hub_bucket = create_s3_infrastructure(hub_info)
+    hub_info["hub_bucket"] = hub_bucket
     create_iam_infrastructure(hub_info)

--- a/src/hubverse_infrastructure/main.py
+++ b/src/hubverse_infrastructure/main.py
@@ -6,7 +6,7 @@ from hubverse_infrastructure.hubs.hub_setup import set_up_hub
 from hubverse_infrastructure.shared.hubverse_transforms import create_transform_infrastructure
 
 # First, create infrastructure components that are shared across hubs.
-create_transform_infrastructure()
+model_output_lambda, model_output_lambda_role = create_transform_infrastructure()
 
 
 # Then, create hub-specific infrastructure.
@@ -19,4 +19,6 @@ def get_hubs() -> list[dict]:
 
 hub_list = get_hubs()
 for hub in hub_list:
+    hub["model_output_lambda"] = model_output_lambda
+    hub["model_output_lambda_role"] = model_output_lambda_role
     set_up_hub(hub)

--- a/src/hubverse_infrastructure/shared/hubverse_transforms.py
+++ b/src/hubverse_infrastructure/shared/hubverse_transforms.py
@@ -210,7 +210,7 @@ def create_lambda_package_placeholder(s3_bucket: str, s3_key: str):
         raise Exception(f"Error when checking for existing lambda package: {s3_bucket}/{s3_key}") from e
 
 
-def create_transform_infrastructure():
+def create_transform_infrastructure() -> tuple[aws.lambda_.Function, aws.iam.Role]:
     """
     Create all AWS infrastructure required to support the lambda function that will
     operate on cloud-based model-output files.
@@ -218,8 +218,11 @@ def create_transform_infrastructure():
     bucket_name = "hubverse-assets"
     lambda_name = "hubverse-transform-model-output"
     lambda_package_location = "s3://hubverse-assets/lambda/hubverse-transform-model-output.zip"
-    lambda_package_path = CloudPath(lambda_package_location)
+    lambda_package_path = CloudPath(lambda_package_location)  # type: ignore
 
     bucket = create_bucket(bucket_name)
-    lambda_role = create_lambda_execution_permissions(lambda_name)
-    create_transform_lambda(lambda_name, lambda_package_path, lambda_role, bucket)
+    model_output_lambda_role = create_lambda_execution_permissions(lambda_name)
+    model_output_lambda = create_transform_lambda(lambda_name, lambda_package_path, model_output_lambda_role, bucket)
+
+    # return the lambda's role so we can attach hub-specific policies to it
+    return model_output_lambda, model_output_lambda_role


### PR DESCRIPTION
Resolves #32 

This is a follow-up to #37, which created the shared AWS Lambda function that is responsible for converting incoming model-output data to a standard format.

This PR adds the actual trigger to invoke the above Lambda. Each hub's S3 bucket will now emit an `s3:ObjectCreated` notification whenever a new model-output file is uploaded to its `raw` prefix.

<img width="1476" alt="image" src="https://github.com/Infectious-Disease-Modeling-Hubs/hubverse-infrastructure/assets/540544/a02c2f80-edf6-48e8-99aa-7d07fce1d206">

(the actual code of the transform function is [managed in a different repo](https://github.com/Infectious-Disease-Modeling-Hubs/hubverse-transform))