### PR TITLE
Provision resources for a test Flusight hub

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -5,5 +5,8 @@ hubs:
 - hub: hubverse-cloud
   org: Infectious-Disease-Modeling-Hubs
   repo: hubverse-cloud
+- hub: bsweger-flusight-forecast
+  org: bsweger
+  repo: FluSight-forecast-hub
 
 


### PR DESCRIPTION
We want to onboard the cdcepi/FluSight-forecast-hub to the cloud. Before officially submitting PRs to the CDC, let's test our end-to-end process on a fork of their repo (to minimize the back and forth if we need to correct any problems).