### PR TITLE
Provision AWS infrastructure for the CDC's FluSight forecast hub

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -8,5 +8,6 @@ hubs:
 - hub: bsweger-flusight-forecast
   org: bsweger
   repo: FluSight-forecast-hub
-
-
+- hub: cdcepi-flusight-forecast-hub
+  org: cdcepi
+  repo: FluSight-forecast-hub


### PR DESCRIPTION
Add a new hub to hubs.yaml. 

- "hub" = the name of the S3 bucket, which we agreed on with the CDC folks. 
- "org" and "repo" are the Github settings used to set up AWS IAM components required for the hub's repo to write to S3 via GitHub actions.