### PR TITLE
Add temp cloud hub for flusight archives

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -11,3 +11,7 @@ hubs:
 - hub: cdcepi-flusight-forecast-hub
   org: cdcepi
   repo: FluSight-forecast-hub
+- hub: temp-flusight-archive-hub
+  org: Infectious-Disease-Modeling-Hubs
+  repo: flusight1_hub
+


### PR DESCRIPTION
This a temporary cloud hub to test a few things before we try onboarding the entire FluSight archives.