### PR TITLE
Switch stack from bsweger personal Pulumi acct to Hubverse team

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: pulumi/actions@v5
         with:
           command: preview
-          stack-name: bsweger/hubverse-aws/hubverse
+          stack-name: hubverse/hubverse-aws/hubverse
           comment-on-pr: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.BSWEGER_PULUMI_DEMO }}

--- a/.github/workflows/pulumi_update.yaml
+++ b/.github/workflows/pulumi_update.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: pulumi/actions@v5
         with:
           command: up
-          stack-name: bsweger/hubverse-aws/hubverse
+          stack-name: hubverse/hubverse-aws/hubverse
           comment-on-pr: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.BSWEGER_PULUMI_DEMO }}


### PR DESCRIPTION
Now that Pulumi has granted us an open-source team license, we can track our infrastructure components using a team-based stack instead of an individual's personal stack.