### PR TITLE
Create AWS infrastructure for hosting rsv-forecast-hub

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -26,3 +26,6 @@ hubs:
 - hub: bsweger-flusight-forecast
   org: bsweger
   repo: FluSight-forecast-hub
+- hub: rsv-forecast-hub
+  org: CDCgov
+  repo: rsv-forecast-hub


### PR DESCRIPTION
This is for the hub at https://github.com/CDCgov/rsv-forecast-hub . They've verified they want the bucket name "rsv-forecast-hub".