### PR TITLE
Consolidate transform Lambda write policies into one inline policy (#132)

### DIFF
--- a/src/hubverse_infrastructure/hubs/iam.py
+++ b/src/hubverse_infrastructure/hubs/iam.py
@@ -102,6 +102,52 @@ def attach_bucket_write_policy(resource_name: str, role: aws.iam.Role, bucket_wr
     aws.iam.RolePolicyAttachment(resource_name=resource_name, role=role.name, policy_arn=bucket_write_policy.id)
 
 
+def create_lambda_bucket_write_policy(hub_names: list[str], model_output_lambda_role: aws.iam.Role):
+    """Grant the shared transform Lambda write access to every hub bucket.
+
+    There is a single transform Lambda (and a single role it assumes), but it must write
+    transformed output back to every hub's bucket. Attaching one managed policy per hub to
+    that shared role hits the AWS PoliciesPerRole quota (10 by default, 20 hard max), so
+    instead we attach a single inline policy that enumerates all hub buckets explicitly.
+
+    Buckets are enumerated explicitly (not via a wildcard) to keep the Lambda's effective
+    permissions identical to a per-hub grant and preserve least privilege. Inline policies
+    do not count against the managed-policy PoliciesPerRole quota. See issue #132.
+    """
+
+    bucket_arns = [f"arn:aws:s3:::{hub_name}" for hub_name in hub_names]
+    object_arns = [f"arn:aws:s3:::{hub_name}/*" for hub_name in hub_names]
+
+    s3_write_policy = aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                actions=[
+                    "s3:ListBucket",
+                ],
+                resources=bucket_arns,
+            ),
+            aws.iam.GetPolicyDocumentStatementArgs(
+                actions=[
+                    "s3:PutObject",
+                    "s3:PutObjectAcl",
+                    "s3:GetObject",
+                    "s3:GetObjectAcl",
+                    "s3:DeleteObject",
+                ],
+                resources=object_arns,
+            ),
+        ]
+    )
+
+    policy_name = "hubverse-transform-model-output-write-bucket-policy"
+    aws.iam.RolePolicy(
+        resource_name=policy_name,
+        name=policy_name,
+        role=model_output_lambda_role.name,
+        policy=s3_write_policy.json,
+    )
+
+
 def create_model_output_lambda_trigger(
     hub_name: str, hub_bucket: aws.s3.Bucket, model_output_lambda: aws.lambda_.Function
 ) -> aws.s3.BucketNotification:
@@ -139,11 +185,9 @@ def create_iam_infrastructure(hub_info: dict):
     hub = hub_info["hub"]
     hub_bucket = hub_info["hub_bucket"]
     model_output_lambda = hub_info["model_output_lambda"]
-    model_output_lambda_role = hub_info["model_output_lambda_role"]
 
     trust_policy = create_trust_policy(org, repo)
     github_role = create_github_role(hub, trust_policy)
     s3_write_policy = create_bucket_write_policy(hub)
     attach_bucket_write_policy(hub, github_role, s3_write_policy)
-    attach_bucket_write_policy(f"{hub}-transform-model-output-lambda", model_output_lambda_role, s3_write_policy)
     create_model_output_lambda_trigger(hub, hub_bucket, model_output_lambda)

--- a/src/hubverse_infrastructure/main.py
+++ b/src/hubverse_infrastructure/main.py
@@ -3,6 +3,7 @@
 import yaml
 
 from hubverse_infrastructure.hubs.hub_setup import set_up_hub
+from hubverse_infrastructure.hubs.iam import create_lambda_bucket_write_policy
 from hubverse_infrastructure.shared.hubverse_transforms import create_transform_infrastructure
 
 # First, create infrastructure components that are shared across hubs.
@@ -20,5 +21,9 @@ def get_hubs() -> list[dict]:
 hub_list = get_hubs()
 for hub in hub_list:
     hub["model_output_lambda"] = model_output_lambda
-    hub["model_output_lambda_role"] = model_output_lambda_role
     set_up_hub(hub)
+
+# Grant the shared transform Lambda write access to every hub bucket via a single inline
+# policy on its role, rather than one managed-policy attachment per hub (which exhausts the
+# AWS PoliciesPerRole quota). See issue #132.
+create_lambda_bucket_write_policy([hub["hub"] for hub in hub_list], model_output_lambda_role)


### PR DESCRIPTION
## Summary

Fixes the `PoliciesPerRole: 10` quota failure that broke deployments after the 10th hub was added (#131). Closes #132.

The shared transform Lambda (`hubverse-transform-model-output`) assumes a single role but must write transformed output back to *every* hub's bucket. Previously, `create_iam_infrastructure()` attached each hub's `{hub}-write-bucket-policy` **managed** policy to that one role inside the per-hub loop, so the role accumulated **one attachment per hub** plus the CloudWatch policy. AWS caps a role at **10 attached managed policies** (hard max 20), which the 10th hub exceeded.

This PR replaces those per-hub attachments on the Lambda role with a **single inline policy** (`create_lambda_bucket_write_policy`) that enumerates write access to all hub buckets, created once after the hub loop in `main.py`. The Lambda role now holds a constant 2 policies (CloudWatch + the consolidated write policy) regardless of hub count.

## Key points

- **No permission change.** The Lambda already had write access to every hub bucket (that's what was overflowing). Buckets are enumerated **explicitly** — no `arn:aws:s3:::*` wildcard — so the effective permission set is identical to before.
- **Per-hub GitHub Actions roles untouched.** Each hub's CI role still gets exactly one policy scoped to its own bucket; that per-hub trust boundary is preserved.
- **Inline, not managed.** Inline role policies don't count against the `PoliciesPerRole` managed-policy quota, and this avoids a create-before-delete ordering conflict during the migration: the ~10 old per-hub attachments can be removed in the same deploy without the role transiently exceeding 10 managed attachments.

## Deployment / migration

On the next `pulumi up`, the existing `{hub}-transform-model-output-lambda` `RolePolicyAttachment` resources are deleted and one `RolePolicy` (`hubverse-transform-model-output-write-bucket-policy`) is created. Once this is deployed, the interim `PoliciesPerRole` → 20 quota bump can be left as-is or reverted; it's no longer load-bearing.

## Testing

- `ruff check .` — pass
- `mypy . --ignore-missing-imports` — pass
- `pytest` — pass

Reviewers may want to confirm via `pulumi preview` that the diff is exactly: delete N `RolePolicyAttachment`s + add 1 `RolePolicy`, with no changes to hub buckets or GitHub Actions roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
